### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ before_script:
 script:
   - vendor/bin/phpunit --configuration phpunit.xml.dist --colors
 
-jobs:
+matrix:
   allow_failures:
     - php: nightly
-
+jobs:
   include:
     - stage: Coding standards
       script:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,4 +5,9 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace PHPFluent\ArrayStorage;
 
+use PHPFluent\ArrayStorage\Filter\Filter;
 use PHPUnit\Framework\TestCase;
-use function count;
 use function iterator_to_array;
 
 /**
@@ -19,7 +19,7 @@ class CollectionTest extends TestCase
         $record = new Record($data);
 
         $factory = $this
-            ->getMockBuilder('PHPFluent\\ArrayStorage\\Factory')
+            ->getMockBuilder(Factory::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -37,11 +37,11 @@ class CollectionTest extends TestCase
     public function testShouldUseFactoryToCreateCriteria(): void
     {
         $factory = $this
-            ->getMockBuilder('PHPFluent\\ArrayStorage\\Factory')
+            ->getMockBuilder(Factory::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $filters = ['foo' => $this->createMock('PHPFluent\\ArrayStorage\\Filter\\Filter')];
+        $filters = ['foo' => $this->createMock(Filter::class)];
 
         $criteria = new Criteria($factory);
         $criteria->addFilter('foo', $filters['foo']);
@@ -90,15 +90,15 @@ class CollectionTest extends TestCase
         $collection->insert(new Record());
         $collection->insert(new Record());
         $collection->insert(new Record());
-        $count = count(iterator_to_array($collection));
+        $count = iterator_to_array($collection);
 
-        $this->assertEquals(3, $count);
+        $this->assertCount(3, $count);
     }
 
     public function testShouldReturnAnInstanceOfCollectionWhenFindingRecords(): void
     {
         $factory = $this
-            ->getMockBuilder('PHPFluent\\ArrayStorage\\Factory')
+            ->getMockBuilder(Factory::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/tests/CriteriaTest.php
+++ b/tests/CriteriaTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PHPFluent\ArrayStorage;
 
+use PHPFluent\ArrayStorage\Filter\EqualTo;
 use PHPFluent\ArrayStorage\Filter\Filter;
 use PHPUnit\Framework\TestCase;
 use UnexpectedValueException;
@@ -41,14 +42,14 @@ class CriteriaTest extends TestCase
         [$index, $filter] = $filters[0];
 
         $this->assertEquals('foo', $index);
-        $this->assertInstanceOf('PHPFluent\\ArrayStorage\\Filter\\EqualTo', $filter);
+        $this->assertInstanceOf(EqualTo::class, $filter);
     }
 
     public function testShouldUseFactoryToCreateFilters(): void
     {
-        $filter = $this->createMock('PHPFluent\\ArrayStorage\\Filter\\Filter');
+        $filter = $this->createMock(Filter::class);
 
-        $factory = $this->createMock('PHPFluent\\ArrayStorage\\Factory');
+        $factory = $this->createMock(Factory::class);
         $factory
             ->expects($this->once())
             ->method('filter')

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -28,13 +28,13 @@ class FactoryTest extends TestCase
     {
         $factory = new Factory();
 
-        $this->assertInstanceOf('PHPFluent\\ArrayStorage\\Collection', $factory->collection());
+        $this->assertInstanceOf(Collection::class, $factory->collection());
     }
 
     public function testShouldReturnInputIfInputIsAlreadyCollection(): void
     {
         $collection = $this
-            ->getMockBuilder('PHPFluent\\ArrayStorage\\Collection')
+            ->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -48,7 +48,7 @@ class FactoryTest extends TestCase
         $factory = new Factory();
         $record = $factory->record();
 
-        $this->assertInstanceOf(__NAMESPACE__.'\\Record', $record);
+        $this->assertInstanceOf(Record::class, $record);
     }
 
     public function testShouldCreateNewRecordFromArray(): void
@@ -57,7 +57,7 @@ class FactoryTest extends TestCase
         $data = [];
         $record = $factory->record($data);
 
-        $this->assertInstanceOf(__NAMESPACE__.'\\Record', $record);
+        $this->assertInstanceOf(Record::class, $record);
     }
 
     public function testShouldCreateNewRecordFromStdClass(): void
@@ -66,7 +66,7 @@ class FactoryTest extends TestCase
         $data = new stdClass();
         $record = $factory->record($data);
 
-        $this->assertInstanceOf(__NAMESPACE__.'\\Record', $record);
+        $this->assertInstanceOf(Record::class, $record);
     }
 
     public function testShouldReturnTheSameInstanceWhenDataIsAlreadyRecordInstance(): void
@@ -83,13 +83,13 @@ class FactoryTest extends TestCase
         $factory = new Factory();
         $criteria = $factory->criteria();
 
-        $this->assertInstanceOf(__NAMESPACE__.'\\Criteria', $criteria);
+        $this->assertInstanceOf(Criteria::class, $criteria);
     }
 
     public function testShouldCreateCriteriaFromKeyValueArrayOfFilters(): void
     {
         $inputFilters = [
-            'foo' => $this->createMock(__NAMESPACE__.'\\Filter\\Filter'),
+            'foo' => $this->createMock(Filter::class),
         ];
         $factory = new Factory();
         $criteria = $factory->criteria($inputFilters);

--- a/tests/RecordTest.php
+++ b/tests/RecordTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PHPFluent\ArrayStorage;
 
 use PHPUnit\Framework\TestCase;
-use function count;
 use function iterator_to_array;
 
 /**
@@ -61,8 +60,6 @@ class RecordTest extends TestCase
         $record->id = 1;
         $record->name = 'Henrique Moody';
 
-        $count = count(iterator_to_array($record));
-
-        $this->assertEquals(2, $count);
+        $this->assertCount(2, iterator_to_array($record));
     }
 }

--- a/tests/StorageTest.php
+++ b/tests/StorageTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PHPFluent\ArrayStorage;
 
 use PHPUnit\Framework\TestCase;
-use function count;
 use function iterator_to_array;
 
 /**
@@ -18,13 +17,13 @@ class StorageTest extends TestCase
         $storage = new Storage();
         $collection = $storage->whatever;
 
-        $this->assertInstanceOf(__NAMESPACE__.'\\Collection', $collection);
+        $this->assertInstanceOf(Collection::class, $collection);
     }
 
     public function testShouldUseFactoryToCreateCollections(): void
     {
         $factory = $this
-            ->getMockBuilder('PHPFluent\\ArrayStorage\\Factory')
+            ->getMockBuilder(Factory::class)
             ->disableOriginalConstructor()
             ->getMock();
         $factory
@@ -50,8 +49,6 @@ class StorageTest extends TestCase
         $storage->foo;
         $storage->bar;
 
-        $count = count(iterator_to_array($storage));
-
-        $this->assertEquals(2, $count);
+        $this->assertCount(2, iterator_to_array($storage));
     }
 }


### PR DESCRIPTION
# Changed log
- Adding the white filter lists to let developers have the coverage to be a code coverage reference.
- Removing the `count` function, using the `assertCount` to assert iterator array length is same as expected.
- Using the magic `::class` to assert it's same as expected instance.